### PR TITLE
Fix bug in initialize script. thanks Ciaran!

### DIFF
--- a/scripts/pgetinker-stage2
+++ b/scripts/pgetinker-stage2
@@ -656,7 +656,7 @@ elif [ "$1" == "initialize" ]; then
         exit
     fi
 
-    if [ $2 == "ci" ]; then
+    if [ "$2" == "ci" ]; then
         proceed=y
     else
         echo "This command will:"


### PR DESCRIPTION
Fixes the following bug in the initialize script.

```
/PGEtinker/scripts/pgetinker-stage2: line 659: [: ==: unary operator expected
```
